### PR TITLE
PWN::Plugins::TransparentBrowser - include usage around instantiating…

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ rvm list gemsets
 $ rvm use ruby-<VERSION>@pwn
 $ gem install --verbose pwn
 $ pwn
-pwn[v0.4.376]:001 >>> PWN.help
+pwn[v0.4.377]:001 >>> PWN.help
 ```
 
 [![Installing the pwn Security Automation Framework](https://raw.githubusercontent.com/0dayInc/pwn/master/documentation/pwn_install.png)](https://youtu.be/G7iLUY4FzsI)
@@ -51,7 +51,7 @@ $ rvm use ruby-<VERSION>@pwn
 $ gem uninstall --all --executables pwn
 $ gem install --verbose pwn
 $ pwn
-pwn[v0.4.376]:001 >>> PWN.help
+pwn[v0.4.377]:001 >>> PWN.help
 ```
 
 

--- a/lib/pwn/plugins/transparent_browser.rb
+++ b/lib/pwn/plugins/transparent_browser.rb
@@ -315,6 +315,9 @@ module PWN
             with_devtools: 'optional - boolean (defaults to false)'
           )
           puts browser_obj1.public_methods
+          * Only works w/ Chrome
+          * All DevTools Commands can be found here:
+          * https://chromedevtools.github.io/devtools-protocol/
           devtools = browser_obj1.driver.devtools
           puts devtools.public_methods
           puts devtools.instance_variables
@@ -323,8 +326,10 @@ module PWN
           devtools.send_cmd('Tracing.requestMemoryDump')
           devtools.send_cmd('Tracing.end')
           puts devtools.instance_variable_get('@messages')
-          * All DevTools Commands can be found here:
-          https://chromedevtools.github.io/devtools-protocol/
+          devtools.send_cmd('Network.enable')
+          last_ws_resp = devtools.instance_variable_get('@messages').last if devtools.instance_variable_get('@messages')['method'] == 'Network.webSocketFrameReceived'
+          puts last_ws_resp
+          devtools.send_cmd('Network.disable')
 
           browser_obj1 = #{self}.linkout(
             browser_obj: 'required - browser_obj returned from #open method)'

--- a/lib/pwn/version.rb
+++ b/lib/pwn/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PWN
-  VERSION = '0.4.376'
+  VERSION = '0.4.377'
 end


### PR DESCRIPTION
… a respective browser devtools/console into an object that can be used in pwn REPL, modules, drivers, etc.