### PR TITLE
PWN::Plugins::TransparentBrowser module - include DevTools examples i…

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ rvm use ruby-3.1.1@pwn
 $ rvm list gemsets
 $ gem install --verbose pwn
 $ pwn
-pwn[v0.4.383]:001 >>> PWN.help
+pwn[v0.4.384]:001 >>> PWN.help
 ```
 
 [![Installing the pwn Security Automation Framework](https://raw.githubusercontent.com/0dayInc/pwn/master/documentation/pwn_install.png)](https://youtu.be/G7iLUY4FzsI)
@@ -52,7 +52,7 @@ $ rvm use ruby-3.1.1@pwn
 $ gem uninstall --all --executables pwn
 $ gem install --verbose pwn
 $ pwn
-pwn[v0.4.383]:001 >>> PWN.help
+pwn[v0.4.384]:001 >>> PWN.help
 ```
 
 

--- a/lib/pwn/version.rb
+++ b/lib/pwn/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PWN
-  VERSION = '0.4.383'
+  VERSION = '0.4.384'
 end


### PR DESCRIPTION
…n #help method.  This includes examples around using the debugger to dump the window DOM object as it steps into every JavaScript call