### PR TITLE
pwn_bdba_groups Driver - bugfix in --parent-group-id parameter && pwn_bdba_scan Driver - clearer messaging to STDOUT when queue timeout / scan aborts are triggered

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ rvm use ruby-3.2.2@pwn
 $ rvm list gemsets
 $ gem install --verbose pwn
 $ pwn
-pwn[v0.4.913]:001 >>> PWN.help
+pwn[v0.4.914]:001 >>> PWN.help
 ```
 
 If you're using a multi-user install of RVM do:
@@ -48,7 +48,7 @@ $ rvm use ruby-3.2.2@pwn
 $ rvm list gemsets
 $ rvmsudo gem install --verbose pwn
 $ pwn
-pwn[v0.4.913]:001 >>> PWN.help
+pwn[v0.4.914]:001 >>> PWN.help
 ```
 
 [![Installing the pwn Security Automation Framework](https://raw.githubusercontent.com/0dayInc/pwn/master/documentation/pwn_install.png)](https://youtu.be/G7iLUY4FzsI)
@@ -63,7 +63,7 @@ $ rvm use ruby-3.2.2@pwn
 $ gem uninstall --all --executables pwn
 $ gem install --verbose pwn
 $ pwn
-pwn[v0.4.913]:001 >>> PWN.help
+pwn[v0.4.914]:001 >>> PWN.help
 ```
 
 If you're using a multi-user install of RVM do:
@@ -73,7 +73,7 @@ $ rvm use ruby-3.2.2@pwn
 $ rvmsudo gem uninstall --all --executables pwn
 $ rvmsudo gem install --verbose pwn
 $ pwn
-pwn[v0.4.913]:001 >>> PWN.help
+pwn[v0.4.914]:001 >>> PWN.help
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,18 @@ $ rvm use ruby-3.2.2@pwn
 $ rvm list gemsets
 $ gem install --verbose pwn
 $ pwn
-pwn[v0.4.912]:001 >>> PWN.help
+pwn[v0.4.913]:001 >>> PWN.help
+```
+
+If you're using a multi-user install of RVM do:
+```
+$ rvm use ruby-3.2.2@global
+$ rvmsudo rvm gemset create pwn
+$ rvm use ruby-3.2.2@pwn
+$ rvm list gemsets
+$ rvmsudo gem install --verbose pwn
+$ pwn
+pwn[v0.4.913]:001 >>> PWN.help
 ```
 
 [![Installing the pwn Security Automation Framework](https://raw.githubusercontent.com/0dayInc/pwn/master/documentation/pwn_install.png)](https://youtu.be/G7iLUY4FzsI)
@@ -52,7 +63,17 @@ $ rvm use ruby-3.2.2@pwn
 $ gem uninstall --all --executables pwn
 $ gem install --verbose pwn
 $ pwn
-pwn[v0.4.912]:001 >>> PWN.help
+pwn[v0.4.913]:001 >>> PWN.help
+```
+
+If you're using a multi-user install of RVM do:
+```
+$ rvm list gemsets
+$ rvm use ruby-3.2.2@pwn
+$ rvmsudo gem uninstall --all --executables pwn
+$ rvmsudo gem install --verbose pwn
+$ pwn
+pwn[v0.4.913]:001 >>> PWN.help
 ```
 
 

--- a/bin/pwn_bdba_groups
+++ b/bin/pwn_bdba_groups
@@ -23,7 +23,7 @@ OptionParser.new do |options|
     opts[:list_group_name] = l
   end
 
-  options.on('-pID', '--parent-group-ID=ID', '<Optional - Black Duck Binary Analysis Parent Group ID to Associate with Group>') do |p|
+  options.on('-pID', '--parent-group-id=ID', '<Optional - Black Duck Binary Analysis Parent Group ID to Associate with Group>') do |p|
     opts[:parent_group_id] = p
   end
 end.parse!

--- a/bin/pwn_bdba_scan
+++ b/bin/pwn_bdba_scan
@@ -110,7 +110,8 @@ begin
     # Cancel queued scan if it's been queued for more than 90 minutes
     if scan_progress_busy_duration > queue_timeout.to_i
       abort_total += 1
-      puts "Scan Queued for More than #{queue_timeout} Seconds. Aborting and Re-Queuing."
+      puts "Scan Queued for More than #{queue_timeout} Seconds."
+      puts "Aborting and Re-Queuing Attempt #{abort_total} of #{scan_attempts}..."
       scan_progress_resp[:products].select { |p| p[:status] == 'B' }.each do |p|
         puts "Abort Queued Scan: #{p[:name]}"
         PWN::Plugins::BlackDuckBinaryAnalysis.abort_product_scan(
@@ -121,7 +122,7 @@ begin
 
       retry if abort_total <= scan_attempts.to_i
 
-      raise "ERROR: BDBA Scan Queued for More than 90 Minutes: #{target_file}"
+      raise "ERROR: BDBA Scan Aborted: #{target_file}"
     end
 
     10.times do

--- a/lib/pwn/version.rb
+++ b/lib/pwn/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PWN
-  VERSION = '0.4.913'
+  VERSION = '0.4.914'
 end

--- a/lib/pwn/version.rb
+++ b/lib/pwn/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PWN
-  VERSION = '0.4.912'
+  VERSION = '0.4.913'
 end


### PR DESCRIPTION
And minor tweaks to README.md when using multi-user install of RVM.