### PR TITLE
pwn_gqrx_scanner Driver - Provide warning for SDRs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ cd /opt/pwn
 $ ./install.sh
 $ ./install.sh ruby-gem
 $ pwn
-pwn[v0.5.61]:001 >>> PWN.help
+pwn[v0.5.62]:001 >>> PWN.help
 ```
 
 [![Installing the pwn Security Automation Framework](https://raw.githubusercontent.com/0dayInc/pwn/master/documentation/pwn_install.png)](https://youtu.be/G7iLUY4FzsI)
@@ -52,7 +52,7 @@ $ rvm use ruby-3.3.0@pwn
 $ gem uninstall --all --executables pwn
 $ gem install --verbose pwn
 $ pwn
-pwn[v0.5.61]:001 >>> PWN.help
+pwn[v0.5.62]:001 >>> PWN.help
 ```
 
 If you're using a multi-user install of RVM do:
@@ -62,7 +62,7 @@ $ rvm use ruby-3.3.0@pwn
 $ rvmsudo gem uninstall --all --executables pwn
 $ rvmsudo gem install --verbose pwn
 $ pwn
-pwn[v0.5.61]:001 >>> PWN.help
+pwn[v0.5.62]:001 >>> PWN.help
 ```
 
 PWN periodically upgrades to the latest version of Ruby which is reflected in `/opt/pwn/.ruby-version`.  The easiest way to upgrade to the latest version of Ruby from a previous PWN installation is to run the following script:

--- a/bin/pwn_gqrx_scanner
+++ b/bin/pwn_gqrx_scanner
@@ -183,6 +183,14 @@ def gqrx_cmd(opts = {})
   # puts response.length
 
   response
+rescue RuntimeError => e
+  puts 'WARNING: RF Gain is not supported by the radio backend.' if e.message.include?('Command: L RF_GAIN')
+  puts 'WARNING: Intermediate Gain is not supported by the radio backend.' if e.message.include?('Command: L IF_GAIN')
+  puts 'WARNING: Baseband Gain is not supported by the radio backend.' if e.message.include?('Command: L BB_GAIN')
+
+  raise e unless e.message.include?('Command: L RF_GAIN') ||
+                 e.message.include?('Command: L IF_GAIN') ||
+                 e.message.include?('Command: L BB_GAIN')
 end
 
 def init_freq(opts = {})
@@ -403,7 +411,7 @@ begin
 
   rf_gain = opts[:rf_gain] ||= 0.0
   rf_gain = rf_gain.to_f
-  squelch_resp = gqrx_cmd(
+  rf_gain_resp = gqrx_cmd(
     gqrx_sock: gqrx_sock,
     cmd: "L RF_GAIN #{rf_gain}",
     resp_ok: 'RPRT 0'
@@ -411,7 +419,7 @@ begin
 
   intermediate_gain = opts[:intermediate_gain] ||= 32.0
   intermediate_gain = intermediate_gain.to_f
-  squelch_resp = gqrx_cmd(
+  intermediate_resp = gqrx_cmd(
     gqrx_sock: gqrx_sock,
     cmd: "L IF_GAIN #{intermediate_gain}",
     resp_ok: 'RPRT 0'
@@ -419,7 +427,7 @@ begin
 
   baseband_gain = opts[:baseband_gain] ||= 10.0
   baseband_gain = baseband_gain.to_f
-  squelch_resp = gqrx_cmd(
+  baseband_resp = gqrx_cmd(
     gqrx_sock: gqrx_sock,
     cmd: "L BB_GAIN #{baseband_gain}",
     resp_ok: 'RPRT 0'

--- a/lib/pwn/version.rb
+++ b/lib/pwn/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PWN
-  VERSION = '0.5.61'
+  VERSION = '0.5.62'
 end


### PR DESCRIPTION
that don't support -R -I or -B parameters (warn instead of instead of fail)