### PR TITLE
PWN::Plugins::TransparentBrowser module - comment out browser_obj[:bi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ cd /opt/pwn
 $ ./install.sh
 $ ./install.sh ruby-gem
 $ pwn
-pwn[v0.5.178]:001 >>> PWN.help
+pwn[v0.5.179]:001 >>> PWN.help
 ```
 
 [![Installing the pwn Security Automation Framework](https://raw.githubusercontent.com/0dayInc/pwn/master/documentation/pwn_install.png)](https://youtu.be/G7iLUY4FzsI)
@@ -52,7 +52,7 @@ $ rvm use ruby-3.3.3@pwn
 $ gem uninstall --all --executables pwn
 $ gem install --verbose pwn
 $ pwn
-pwn[v0.5.178]:001 >>> PWN.help
+pwn[v0.5.179]:001 >>> PWN.help
 ```
 
 If you're using a multi-user install of RVM do:
@@ -62,7 +62,7 @@ $ rvm use ruby-3.3.3@pwn
 $ rvmsudo gem uninstall --all --executables pwn
 $ rvmsudo gem install --verbose pwn
 $ pwn
-pwn[v0.5.178]:001 >>> PWN.help
+pwn[v0.5.179]:001 >>> PWN.help
 ```
 
 PWN periodically upgrades to the latest version of Ruby which is reflected in `/opt/pwn/.ruby-version`.  The easiest way to upgrade to the latest version of Ruby from a previous PWN installation is to run the following script:

--- a/lib/pwn/plugins/transparent_browser.rb
+++ b/lib/pwn/plugins/transparent_browser.rb
@@ -58,7 +58,9 @@ module PWN
           browser_obj[:tor_obj] = tor_obj
         end
 
+        devtools_supported = %i[chrome headless_chrome firefox headless_firefox headless]
         with_devtools = opts[:with_devtools] ||= true
+        with_devtools = false unless devtools_supported.include?(browser_type)
 
         # Let's crank up the default timeout from 30 seconds to 15 min for slow sites
         Watir.default_timeout = 900
@@ -277,32 +279,34 @@ module PWN
             browser_obj[:browser] = Faye::WebSocket::Client.new('')
           end
         else
-          puts 'Error: browser_type only supports :firefox, :chrome, :headless, :rest, or :websocket'
+          puts 'Error: browser_type only supports :firefox, :chrome, :headless, :headless_chrome, :headless_firefox, :rest, :websocket'
           return nil
         end
 
-        browser_type = browser_obj[:type]
-        supported = %i[chrome headless_chrome firefox headless_firefox headless]
-        if with_devtools && supported.include?(browser_type)
-          browser_obj[:browser].goto('about:blank')
+        if devtools_supported.include?(browser_type)
           rand_tab = SecureRandom.hex(8)
+          browser_obj[:browser].goto('about:about')
           browser_obj[:browser].execute_script("document.title = '#{rand_tab}'")
 
-          browser_obj[:devtools] = browser_obj[:browser].driver.devtools
-          browser_obj[:bidi] = browser_obj[:browser].driver.bidi
+          if with_devtools
+            browser_obj[:devtools] = browser_obj[:browser].driver.devtools
 
-          # browser_obj[:devtools].send_cmd('DOM.enable')
-          # browser_obj[:devtools].send_cmd('Log.enable')
-          # browser_obj[:devtools].send_cmd('Network.enable')
-          # browser_obj[:devtools].send_cmd('Page.enable')
-          # browser_obj[:devtools].send_cmd('Runtime.enable')
-          # browser_obj[:devtools].send_cmd('Security.enable')
+            browser_obj[:devtools].send_cmd('DOM.enable')
+            browser_obj[:devtools].send_cmd('Log.enable')
+            browser_obj[:devtools].send_cmd('Network.enable')
+            browser_obj[:devtools].send_cmd('Page.enable')
+            browser_obj[:devtools].send_cmd('Runtime.enable')
+            browser_obj[:devtools].send_cmd('Security.enable')
 
-          # if browser_type == :chrome || browser_type == :headless_chrome
-          #   browser_obj[:devtools].send_cmd('Debugger.enable')
-          #   browser_obj[:devtools].send_cmd('DOMStorage.enable')
-          #   browser_obj[:devtools].send_cmd('DOMSnapshot.enable')
-          # end
+            chrome_browser_types = %i[chrome headless_chrome]
+            if chrome_browser_types.include?(browser_type)
+              browser_obj[:devtools].send_cmd('Debugger.enable')
+              browser_obj[:devtools].send_cmd('DOMStorage.enable')
+              browser_obj[:devtools].send_cmd('DOMSnapshot.enable')
+            end
+
+            # browser_obj[:bidi] = browser_obj[:browser].driver.bidi
+          end
         end
 
         browser_obj

--- a/lib/pwn/version.rb
+++ b/lib/pwn/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PWN
-  VERSION = '0.5.178'
+  VERSION = '0.5.179'
 end


### PR DESCRIPTION
…di] until this error is addressed: `Failed to initialize BiDi Mapper: TypeError: Failed to set the innerHTML property on Element: This document requires TrustedHTML assignment.`