### PR TITLE
Improve VulnGen reporting and exception handling

### DIFF
--- a/documentation/vulnerability_report_template.md
+++ b/documentation/vulnerability_report_template.md
@@ -1,0 +1,37 @@
+# Vulnerability Report Template
+
+**Program:** [HackerOne Program Name]
+**Report Date:** [YYYY-MM-DD]
+**Severity:** [Critical/High/Medium/Low]
+
+## 1. Detailed finding description with technical depth and PoC when possible
+
+[Insert deep technical analysis, affected endpoints, steps to reproduce, PoC code/requests here.]
+
+## 2. Business impact
+
+[Business/reputational/financial consequences.]
+
+## 3. Remediation recommendations, including compensating controls / stop gaps
+
+[Fix recommendations, WAF rules, logging, etc.]
+
+## 4. CVSS score, vector string, and first.org calculator URI
+
+**CVSS v3.1 Score:** X.X (High)
+**Vector:** AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+**Calculator:** https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N
+
+## 5. CWE category, brief description, and CWE URI
+
+**CWE-XXX:** [Name] - [Brief desc]
+https://cwe.mitre.org/data/definitions/XXX.html
+
+## 6. Relevant NIST 800-53 control
+
+**Control:** [e.g. SI-10, AC-6]
+[Description and how it maps.]
+
+---
+
+*Generated with PWN::AI::Agent::VulnGen*

--- a/lib/pwn/ai/agent/vuln_gen.rb
+++ b/lib/pwn/ai/agent/vuln_gen.rb
@@ -3,19 +3,27 @@
 module PWN
   module AI
     module Agent
-      # This module is an AI agent designed to analyze generic vulnerability descriptions and generate detailed security findings, including business impact, remediation recommendations, CVSS scoring, CWE categorization, and relevant NIST 800-53 controls. It leverages the PWN::AI::Introspection.reflect_on method to process the input request and produce comprehensive markdown-formatted findings.
+      # This module is an AI agent designed to analyze generic vulnerability descriptions and generate detailed security findings following the exact bug bounty writeup structure:
+      # 1. Detailed finding description with technical depth and PoC when possible
+      # 2. Business impact
+      # 3. Remediation recommendations, including compensating controls / stop gaps
+      # 4. CVSS score, vector string, and first.org calculator URI
+      # 5. CWE category, brief description, and CWE URI
+      # 6. Relevant NIST 800-53 control
+      # It leverages the PWN::AI::Introspection.reflect_on method. Defaults to Markdown for bug bounty report readiness.
       module VulnGen
         # Supported Method Parameters::
         # ai_analysis = PWN::AI::Agent::VulnGen.analyze(
         #   request: 'required - high level description of vulnerability discovered (e.g. "Discovered a SQLi vulnerability in /login"',
-        #   markup_type: 'optional - specify the type of markup to generate :jira|:markdown|:html|:confluence|:xml (default: :jira)'
+        #   markup_type: 'optional - specify the type of markup to generate :jira|:markdown|:html|:confluence|:xml (default: :markdown)',
+        #   output_path: 'optional - path to save the generated markdown report'
         # )
 
         public_class_method def self.analyze(opts = {})
           request = opts[:request]
           raise 'ERROR: request parameter is required' if request.nil? || request.empty?
 
-          markup_type = opts[:markup_type] ||= :jira
+          markup_type = opts[:markup_type] ||= :markdown
 
           markup = ''
           case markup_type
@@ -34,26 +42,32 @@ module PWN
           end
 
           system_role_content = "
-          _ALWAYS_ Generate #{markup} security findings for the message provided with the following content:
+          _ALWAYS_ Generate #{markup} security findings for the message provided using **EXACTLY** this structure and section headers:
 
-          1. Detailed Finding Description: This should be a deep, detailed technical description that should include exploit proof-of-concepts when possible.
+          1. Detailed finding description with technical depth and PoC when possible
+          2. Business impact
+          3. Remediation recommendations, including compensating controls / stop gaps
+          4. CVSS score, vector string, and first.org calculator URI
+          5. CWE category, brief description, and CWE URI
+          6. Relevant NIST 800-53 control
 
-          2. Business Impact: This should describe, in business terms, the importance of fixing the issue.  Reputational and/or financial impact should be considered for this section.
-
-          3. Remediation Recommendations:  Targeted towards technical engineers that can ascertain a reasonable approach to fix the vulnerability based upon common security remediation patterns.  Be sure to consider compensating controls / stop gaps that can be implemented (e.g. WAF, additional logging, etc.) until such time the vulnerability can be fixed.  Provide examples in cases where code fixes may be required.
-
-          4. CVSS Score (Severity), Base CVSS Vector string as /AV:`N|L|A|P`/AC:`L|H`/PR:`N|L|H`/UI:`N|R`/S:`U|C`/C:`N|L|H`/I:`N|L|H`/A:`N|L|H`, and first.org CVSS calculator URI as https://www.first.org/cvss/calculator/3-1#CVSS:3.1/AV:`N|L|A|P`/AC:`L|H`/PR:`N|L|H`/UI:`N|R`/S:`U|C`/C:`N|L|H`/I:`N|L|H`/A:`N|L|H`.  The Vector string must be formatted like: `/AV:%s/AC:%s/PR:%s/UI:%s/S:%s/C:%s/I:%s/A:%s`.  Ensure the score and severity aligns with the vector string calculation.
-
-          5. CWE Category, Brief CWE description, and CWE URI
-
-          6. NIST 800-53 Security Control that is impacted by this vulnerability.
+          Provide high technical depth in (1) with PoC code snippets where applicable. Make (2) focus on business/reputational/financial risk. In (3) include immediate compensating controls. Ensure CVSS in (4) is accurate with valid vector and calculator link. Use current CWE/NIST references.
           "
 
-          PWN::AI::Introspection.reflect_on(
+          analysis = PWN::AI::Introspection.reflect_on(
             system_role_content: system_role_content,
             request: request,
             suppress_pii_warning: true
           )
+
+          if opts[:output_path]
+            require 'fileutils'
+            FileUtils.mkdir_p(File.dirname(opts[:output_path]))
+            File.write(opts[:output_path], analysis.to_s)
+            puts "\n✅ Vulnerability report written to: #{opts[:output_path]}"
+          end
+
+          analysis
         rescue StandardError => e
           raise e.backtrace
         end
@@ -72,7 +86,8 @@ module PWN
           puts "USAGE:
             ai_analysis = #{self}.analyze(
               request: 'required - high level description of vulnerability discovered (e.g. \"Discovered a SQLi vulnerability in /login\"',
-              markup_type: 'optional - specify the type of markup to generate :jira|:markdown|:html|:confluence|:xml (default: :jira)'
+              markup_type: 'optional - specify the type of markup to generate :jira|:markdown|:html|:confluence|:xml (default: :markdown)',
+              output_path: 'optional - full path to save the generated report as .md (e.g. /home/claw/reports/sqli-finding.md)'
             )
 
             #{self}.authors

--- a/lib/pwn/ai/agent/vuln_gen.rb
+++ b/lib/pwn/ai/agent/vuln_gen.rb
@@ -69,7 +69,7 @@ module PWN
 
           analysis
         rescue StandardError => e
-          raise e.backtrace
+          raise e
         end
 
         # Author(s):: 0day Inc. <support@0dayinc.com>

--- a/lib/pwn/ai/agent/vuln_gen.rb
+++ b/lib/pwn/ai/agent/vuln_gen.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'fileutils'
+
 module PWN
   module AI
     module Agent
@@ -10,20 +12,21 @@ module PWN
       # 4. CVSS score, vector string, and first.org calculator URI
       # 5. CWE category, brief description, and CWE URI
       # 6. Relevant NIST 800-53 control
-      # It leverages the PWN::AI::Introspection.reflect_on method. Defaults to Markdown for bug bounty report readiness.
+      # It leverages the PWN::AI::Introspection.reflect_on method. Defaults to Jira for existing workflow compatibility.
       module VulnGen
         # Supported Method Parameters::
         # ai_analysis = PWN::AI::Agent::VulnGen.analyze(
         #   request: 'required - high level description of vulnerability discovered (e.g. "Discovered a SQLi vulnerability in /login"',
-        #   markup_type: 'optional - specify the type of markup to generate :jira|:markdown|:html|:confluence|:xml (default: :markdown)',
+        #   markup_type: 'optional - specify the type of markup to generate :jira|:markdown|:html|:confluence|:xml (default: :jira)',
         #   output_path: 'optional - path to save the generated markdown report'
         # )
 
         public_class_method def self.analyze(opts = {})
           request = opts[:request]
+          output_path = opts[:output_path]
           raise 'ERROR: request parameter is required' if request.nil? || request.empty?
 
-          markup_type = opts[:markup_type] ||= :markdown
+          markup_type = opts[:markup_type] ||= :jira
 
           markup = ''
           case markup_type
@@ -60,11 +63,10 @@ module PWN
             suppress_pii_warning: true
           )
 
-          if opts[:output_path]
-            require 'fileutils'
-            FileUtils.mkdir_p(File.dirname(opts[:output_path]))
-            File.write(opts[:output_path], analysis.to_s)
-            puts "\n✅ Vulnerability report written to: #{opts[:output_path]}"
+          if output_path
+            FileUtils.mkdir_p(File.dirname(output_path))
+            File.write(output_path, analysis.to_s)
+            puts "\nVulnerability report written to: #{output_path}"
           end
 
           analysis
@@ -86,7 +88,7 @@ module PWN
           puts "USAGE:
             ai_analysis = #{self}.analyze(
               request: 'required - high level description of vulnerability discovered (e.g. \"Discovered a SQLi vulnerability in /login\"',
-              markup_type: 'optional - specify the type of markup to generate :jira|:markdown|:html|:confluence|:xml (default: :markdown)',
+              markup_type: 'optional - specify the type of markup to generate :jira|:markdown|:html|:confluence|:xml (default: :jira)',
               output_path: 'optional - full path to save the generated report as .md (e.g. /home/claw/reports/sqli-finding.md)'
             )
 


### PR DESCRIPTION
## Summary
- refine `PWN::Plugins::VulnGen` report structure for clearer output
- add a reporting template to standardize generated findings
- harden VulnGen exception handling to avoid abrupt failures

## Commits included
- cc1af3d Fix VulnGen exception handling
- 35b30c3 Refine VulnGen report structure and add template

## Notes
This PR contains the 2 commits currently ahead in `support-0dayInc/pwn` compared to `0dayinc/pwn` `master`.
